### PR TITLE
SRE-2001 - Fix panic caused by closing a closed connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,6 +18,9 @@ type ZookeeperConnection interface {
 	// Close this connection
 	Close()
 
+	//Gets State of this connection.
+	State() zk.State
+
 	// Create a node with the given path.
 	//
 	// The node data will be the given data, and node acl will be the given acl.

--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ type ZookeeperConnection interface {
 	// Close this connection
 	Close()
 
-	//Gets State of this connection.
+	// Gets State of this connection.
 	State() zk.State
 
 	// Create a node with the given path.

--- a/state.go
+++ b/state.go
@@ -132,7 +132,7 @@ func (h *handleHolder) internalClose() error {
 	if h.Helper() != nil {
 		if conn, err := h.getZookeeperConnection(); err != nil {
 			return err
-		} else if conn != nil {
+		} else if conn != nil && conn.State() != zk.StateDisconnected {
 			conn.Close()
 		}
 	}


### PR DESCRIPTION
In the curator implementation of the ZookeeperConnection interface, I added a field that retrieved the state of the connection. The method is implemented by [go-zookeeper](https://github.com/samuel/go-zookeeper/blob/master/zk/conn.go#L322).

Then, we simply check the state of the connection, and if it is not set to `StateDisconnected`, then we close the connection, by calling `conn.Close()`