### PR TITLE
Update Zookeeper Go library to latest.

### DIFF
--- a/acl.go
+++ b/acl.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 var (

--- a/acl_test.go
+++ b/acl_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/api.go
+++ b/api.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 var (

--- a/builder.go
+++ b/builder.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 type CreateBuilder interface {

--- a/children.go
+++ b/children.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 type getChildrenBuilder struct {

--- a/children_test.go
+++ b/children_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/client.go
+++ b/client.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 type ZookeeperConnection interface {

--- a/create.go
+++ b/create.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 type createBuilder struct {

--- a/create_test.go
+++ b/create_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/data.go
+++ b/data.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 type getDataBuilder struct {

--- a/data_test.go
+++ b/data_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/delete.go
+++ b/delete.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 type deleteBuilder struct {

--- a/delete_test.go
+++ b/delete_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/event.go
+++ b/event.go
@@ -3,7 +3,7 @@ package curator
 import (
 	"fmt"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 type CuratorEventType int

--- a/exists.go
+++ b/exists.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 type checkExistsBuilder struct {

--- a/exists_test.go
+++ b/exists_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/framework.go
+++ b/framework.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 const (

--- a/framework_test.go
+++ b/framework_test.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 )
 
 func StartNewTestingClient(t *testing.T) CuratorFramework {
-	zkCluster, err := zk.StartTestCluster(1, nil, nil)
+	zkCluster, err := zk.StartTestCluster(1, nil, nil, nil)
 	assert.NoError(t, err)
 	var c = NewClient(fmt.Sprintf("127.0.0.1:%d", zkCluster.Servers[0].Port), nil)
 	c.ConnectionStateListenable().AddListener(NewConnectionStateListener(

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -5,10 +5,9 @@ import (
 	"math/rand"
 	"reflect"
 	"sync"
-	"testing"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -121,6 +120,10 @@ type mockConn struct {
 
 	log        infof
 	operations []interface{}
+}
+
+func (c *mockConn) State() zk.State {
+	return zk.StateConnected
 }
 
 func (c *mockConn) AddAuth(scheme string, auth []byte) error {
@@ -821,7 +824,7 @@ func (c *mockContainer) WithNamespace(namespace string) *mockContainer {
 	return c
 }
 
-func (c *mockContainer) Test(t *testing.T, callback interface{}) {
+func (c *mockContainer) Test(t suite.TestingT, callback interface{}) {
 	var client CuratorFramework
 	var events chan zk.Event
 	var wg *sync.WaitGroup

--- a/paths.go
+++ b/paths.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"unicode"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 const (

--- a/paths_test.go
+++ b/paths_test.go
@@ -3,7 +3,7 @@ package curator
 import (
 	"testing"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/retry.go
+++ b/retry.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 // Abstraction for retry policies to sleep

--- a/retry_test.go
+++ b/retry_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/state.go
+++ b/state.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 const MAX_BACKGROUND_ERRORS = 10

--- a/state_test.go
+++ b/state_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"

--- a/sync_test.go
+++ b/sync_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/transaction.go
+++ b/transaction.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 // Transactional/atomic operations.

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -3,7 +3,7 @@ package curator
 import (
 	"testing"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/watcher.go
+++ b/watcher.go
@@ -3,7 +3,7 @@ package curator
 import (
 	"sync"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 type Watcher interface {

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
This is to resolve a Curator bug that, when zookeeper is down curator
panic instead of waiting for reconnecting

J=SRE-2654
TEST=manual

Test a RPC server locally connected to a local Zookeeper instance.
Observed RPC server behavior while shutting down zookeeper instance.