### PR TITLE
curator: use yext fork of go-zookeeper/zk library

### DIFF
--- a/acl.go
+++ b/acl.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 var (

--- a/acl_test.go
+++ b/acl_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/api.go
+++ b/api.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 var (

--- a/builder.go
+++ b/builder.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 type CreateBuilder interface {

--- a/children.go
+++ b/children.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 type getChildrenBuilder struct {

--- a/children_test.go
+++ b/children_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/client.go
+++ b/client.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 type ZookeeperConnection interface {

--- a/create.go
+++ b/create.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 type createBuilder struct {

--- a/create_test.go
+++ b/create_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/data.go
+++ b/data.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 type getDataBuilder struct {

--- a/data_test.go
+++ b/data_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/delete.go
+++ b/delete.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 type deleteBuilder struct {

--- a/delete_test.go
+++ b/delete_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/event.go
+++ b/event.go
@@ -3,7 +3,7 @@ package curator
 import (
 	"fmt"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 type CuratorEventType int

--- a/exists.go
+++ b/exists.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 type checkExistsBuilder struct {

--- a/exists_test.go
+++ b/exists_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/framework.go
+++ b/framework.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 const (

--- a/framework_test.go
+++ b/framework_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"

--- a/paths.go
+++ b/paths.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"unicode"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 const (

--- a/paths_test.go
+++ b/paths_test.go
@@ -3,7 +3,7 @@ package curator
 import (
 	"testing"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/retry.go
+++ b/retry.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 // Abstraction for retry policies to sleep

--- a/retry_test.go
+++ b/retry_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/state.go
+++ b/state.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 const MAX_BACKGROUND_ERRORS = 10

--- a/state_test.go
+++ b/state_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"

--- a/sync_test.go
+++ b/sync_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/transaction.go
+++ b/transaction.go
@@ -1,7 +1,7 @@
 package curator
 
 import (
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 // Transactional/atomic operations.

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -3,7 +3,7 @@ package curator
 import (
 	"testing"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/watcher.go
+++ b/watcher.go
@@ -3,7 +3,7 @@ package curator
 import (
 	"sync"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 type Watcher interface {

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Performed find-and-replace with:
  $ ruplacer --go 'github.com/go-zookeeper/zk' 'github.com/yext/zk'

J=SRE-3085
TEST=manual
  verified a go service in alpha utilizing curator started up